### PR TITLE
Feat/#88: Tests for feedback functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9545,6 +9545,12 @@
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
     },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+      "dev": true
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -10065,6 +10071,18 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
           "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
         }
+      }
+    },
+    "nock": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.0.7.tgz",
+      "integrity": "sha512-WBz73VYIjdbO6BwmXODRQLtn7B5tldA9pNpWJe5QTtTEscQlY5KXU4srnGzBOK2fWakkXj69gfTnXGzmrsaRWw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash.set": "^4.3.2",
+        "propagate": "^2.0.0"
       }
     },
     "node-fetch": {
@@ -11952,6 +11970,12 @@
           "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true
     },
     "protobufjs": {
       "version": "6.10.2",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "express": "^4.17.1",
     "http-proxy-middleware": "^1.0.6",
     "micromatch": "^4.0.2",
+    "nock": "^13.0.7",
     "nodemailer": "^6.4.18",
     "shelljs": "^0.8.4"
   },

--- a/src/components/pageComponents/CustomSnackbar.js
+++ b/src/components/pageComponents/CustomSnackbar.js
@@ -7,19 +7,20 @@ import CloseIcon from "@material-ui/icons/Close";
 export default function CustomSnackbar(props) {
   // buttonText and onButtonClick are optional properties
   // onClose and onButtonClick should be functions
-  const { message, isOpen, onClose, buttonText, onButtonClick } = props;
+  const { buttonText, onButtonClick, ...rest } = props;
 
   return (
     <div>
       <Snackbar
+        {...rest}
         anchorOrigin={{
           vertical: "bottom",
           horizontal: "center",
         }}
-        open={isOpen}
+        // open={isOpen}
         autoHideDuration={3500}
-        onClose={onClose}
-        message={message}
+        // onClose={onClose}
+        // message={message}
         action={
           <React.Fragment>
             {buttonText && onButtonClick ? (
@@ -33,7 +34,7 @@ export default function CustomSnackbar(props) {
               size="small"
               aria-label="close"
               color="inherit"
-              onClick={onClose}
+              onClick={rest.onClose}
             >
               <CloseIcon fontSize="small" />
             </IconButton>

--- a/src/components/pageComponents/CustomSnackbar.js
+++ b/src/components/pageComponents/CustomSnackbar.js
@@ -17,10 +17,7 @@ export default function CustomSnackbar(props) {
           vertical: "bottom",
           horizontal: "center",
         }}
-        // open={isOpen}
         autoHideDuration={3500}
-        // onClose={onClose}
-        // message={message}
         action={
           <React.Fragment>
             {buttonText && onButtonClick ? (

--- a/src/components/pages/Feedbackscreen.js
+++ b/src/components/pages/Feedbackscreen.js
@@ -30,7 +30,7 @@ const styles = (theme) => ({
 class Feedbackscreen extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { value: "", snackbarOpen: false };
+    this.state = { value: "", snackbarIsOpen: false };
     this.handleChange = this.handleChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
     this.snackbarMessage = "undefined";
@@ -46,15 +46,14 @@ class Feedbackscreen extends React.Component {
         this.provideUserFeedback("Feedback erhalten");
         this.setState({ value: "" });
       })
-      .catch((err) => {
-        console.log(err);
+      .catch(() => {
         this.provideUserFeedback("Fehler beim Senden");
       });
   }
 
   provideUserFeedback(message) {
     this.snackbarMessage = message;
-    this.setState({ snackbarOpen: true });
+    this.setState({ snackbarIsOpen: true });
   }
 
   render() {
@@ -88,8 +87,8 @@ class Feedbackscreen extends React.Component {
           </Button>
           <CustomSnackbar
             data-testid="feedback-snackbar"
-            open={this.state.snackbarOpen}
-            onClose={() => this.setState({ snackbarOpen: false })}
+            open={this.state.snackbarIsOpen}
+            onClose={() => this.setState({ snackbarIsOpen: false })}
             message={this.snackbarMessage}
           ></CustomSnackbar>
         </div>

--- a/src/components/pages/Feedbackscreen.js
+++ b/src/components/pages/Feedbackscreen.js
@@ -2,6 +2,7 @@ import React from "react";
 import { Button, withStyles } from "@material-ui/core/";
 import TopAppBar from "../pageComponents/TopAppBar";
 import CustomSnackbar from "../pageComponents/CustomSnackbar";
+import { sendFeedback } from "../services/sendFeedback";
 
 const styles = (theme) => ({
   container: {
@@ -40,22 +41,13 @@ class Feedbackscreen extends React.Component {
   }
 
   handleSubmit() {
-    fetch("/api/feedback", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json; charset=UTF-8",
-      },
-      body: JSON.stringify({ message: this.state.value }),
-    })
-      .then((res) => {
-        if (res.status === 200) {
-          this.provideUserFeedback("Feedback erhalten");
-          this.setState({ value: "" });
-        } else {
-          this.provideUserFeedback("Fehler beim Senden");
-        }
+    sendFeedback(this.state.value)
+      .then(() => {
+        this.provideUserFeedback("Feedback erhalten");
+        this.setState({ value: "" });
       })
       .catch((err) => {
+        console.log(err);
         this.provideUserFeedback("Fehler beim Senden");
       });
   }
@@ -95,7 +87,8 @@ class Feedbackscreen extends React.Component {
             Senden
           </Button>
           <CustomSnackbar
-            isOpen={this.state.snackbarOpen}
+            data-testid="feedback-snackbar"
+            open={this.state.snackbarOpen}
             onClose={() => this.setState({ snackbarOpen: false })}
             message={this.snackbarMessage}
           ></CustomSnackbar>

--- a/src/components/services/sendFeedback.js
+++ b/src/components/services/sendFeedback.js
@@ -1,0 +1,20 @@
+export async function sendFeedback(msg) {
+  let res;
+  try {
+    res = await fetch("/api/feedback", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json; charset=UTF-8",
+      },
+      body: JSON.stringify({ message: msg }),
+    });
+  } catch (error) {
+    throw new Error(error);
+  }
+
+  if (res.status === 200) {
+    return { success: true };
+  } else {
+    throw new Error(`${res.status}: ${res.statusText}`);
+  }
+}

--- a/src/components/services/sendFeedback.js
+++ b/src/components/services/sendFeedback.js
@@ -13,7 +13,7 @@ export async function sendFeedback(msg) {
   }
 
   if (res.status === 200) {
-    return { success: true };
+    return true;
   } else {
     throw new Error(`${res.status}: ${res.statusText}`);
   }

--- a/src/tests/pageComponents/CostumSnackbar.test.js
+++ b/src/tests/pageComponents/CostumSnackbar.test.js
@@ -4,23 +4,24 @@ import "@testing-library/jest-dom/extend-expect";
 
 import CostumSnackbar from "../../components/pageComponents/CustomSnackbar";
 
-test("check if snack bis hidden if open is set false", () => {
+test("check if snackbar is hidden if open is set false", () => {
   render(<CostumSnackbar open={false} message="snackbar msg" />);
   const snackbar = screen.queryByText("snackbar msg");
+
   expect(snackbar).not.toBeInTheDocument();
 });
 
-test("check if snack bis visible if open is set true", () => {
+test("check if snackbar is visible if open is set true", () => {
   render(<CostumSnackbar open={true} message="snackbar msg" />);
   const snackbar = screen.getByText("snackbar msg");
+
   expect(snackbar).toBeInTheDocument();
 });
 
 test("check if close icon click is processed", () => {
   const onCloseCallback = jest.fn();
   render(<CostumSnackbar open={true} onClose={onCloseCallback} />);
-  const closeButton = screen.getByLabelText("close");
-  fireEvent.click(closeButton);
 
+  fireEvent.click(screen.getByLabelText("close"));
   expect(onCloseCallback).toBeCalledTimes(1);
 });

--- a/src/tests/pageComponents/CostumSnackbar.test.js
+++ b/src/tests/pageComponents/CostumSnackbar.test.js
@@ -1,0 +1,26 @@
+import React from "react";
+import { render, fireEvent, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+
+import CostumSnackbar from "../../components/pageComponents/CustomSnackbar";
+
+test("check if snack bis hidden if open is set false", () => {
+  render(<CostumSnackbar open={false} message="snackbar msg" />);
+  const snackbar = screen.queryByText("snackbar msg");
+  expect(snackbar).not.toBeInTheDocument();
+});
+
+test("check if snack bis visible if open is set true", () => {
+  render(<CostumSnackbar open={true} message="snackbar msg" />);
+  const snackbar = screen.getByText("snackbar msg");
+  expect(snackbar).toBeInTheDocument();
+});
+
+test("check if close icon click is processed", () => {
+  const onCloseCallback = jest.fn();
+  render(<CostumSnackbar open={true} onClose={onCloseCallback} />);
+  const closeButton = screen.getByLabelText("close");
+  fireEvent.click(closeButton);
+
+  expect(onCloseCallback).toBeCalledTimes(1);
+});

--- a/src/tests/pages/Feedbackscreen.test.js
+++ b/src/tests/pages/Feedbackscreen.test.js
@@ -46,7 +46,7 @@ test("check if textarea is cleared after sendFeedback returns success", async ()
     textarea = getByTestId("feedback-textarea");
   fireEvent.change(textarea, { target: { value: "fake user input" } });
 
-  // fake positive response from sendFeedback sevice
+  // fake positive response from sendFeedback service
   sendFeedback.mockImplementation(() => Promise.resolve(true));
 
   // click button and wait for mock function to be returned
@@ -56,7 +56,7 @@ test("check if textarea is cleared after sendFeedback returns success", async ()
   expect(textarea.value).toBe("");
 });
 
-test("check if textarea is not cleared if sendFeedback returns seccess", async () => {
+test("check if textarea is not cleared if sendFeedback returns error", async () => {
   const { getByTestId } = render(
       <Router>
         <Feedbackscreen />
@@ -65,7 +65,7 @@ test("check if textarea is not cleared if sendFeedback returns seccess", async (
     textarea = getByTestId("feedback-textarea");
   fireEvent.change(textarea, { target: { value: "fake user input" } });
 
-  // fake negative response from sendFeedback sevice
+  // fake negative response from sendFeedback service
   sendFeedback.mockImplementation(() =>
     Promise.reject("thrown for testing purposes")
   );

--- a/src/tests/pages/Feedbackscreen.test.js
+++ b/src/tests/pages/Feedbackscreen.test.js
@@ -4,8 +4,10 @@ import "@testing-library/jest-dom/extend-expect";
 import { BrowserRouter as Router } from "react-router-dom";
 
 import Feedbackscreen from "../../components/pages/Feedbackscreen";
+import { sendFeedback } from "../../components/services/sendFeedback";
+jest.mock("../../components/services/sendFeedback");
 
-it("check if screen content displays", () => {
+test("check if screen content displays", () => {
   const { getByTestId } = render(
     <Router>
       <Feedbackscreen />
@@ -22,7 +24,7 @@ it("check if screen content displays", () => {
   expect(button).toBeInTheDocument();
 });
 
-it("check if textarea displays text", () => {
+test("check if textarea displays text", () => {
   const { getByTestId } = render(
     <Router>
       <Feedbackscreen />
@@ -33,4 +35,55 @@ it("check if textarea displays text", () => {
   fireEvent.change(textarea, { target: { value: "feedback" } });
 
   expect(textarea.value).toBe("feedback");
+});
+
+test("check if textarea is cleared and snackbar displayed after sendFeedback returns success", (done) => {
+  const { getByTestId } = render(
+    <Router>
+      <Feedbackscreen />
+    </Router>
+  );
+
+  const textarea = getByTestId("feedback-textarea");
+  const button = getByTestId("feedback-button");
+
+  fireEvent.change(textarea, { target: { value: "feedback" } });
+  expect(textarea.value).toBe("feedback");
+
+  sendFeedback.mockImplementationOnce(() => Promise.resolve({ success: true }));
+
+  fireEvent.click(button);
+
+  setTimeout(() => {
+    expect(textarea.value).toBe("");
+
+    const snackbar = getByTestId("feedback-snackbar");
+    expect(snackbar).toBeInTheDocument();
+    done();
+  }, 300);
+});
+
+test("check if textarea is not cleared and snackbar displayed when sendFeedback returns error", (done) => {
+  const { getByTestId } = render(
+    <Router>
+      <Feedbackscreen />
+    </Router>
+  );
+
+  const textarea = getByTestId("feedback-textarea");
+  const button = getByTestId("feedback-button");
+
+  fireEvent.change(textarea, { target: { value: "feedback" } });
+  expect(textarea.value).toBe("feedback");
+
+  sendFeedback.mockImplementationOnce(() => Promise.reject("error"));
+  fireEvent.click(button);
+
+  setTimeout(() => {
+    expect(textarea.value).toBe("feedback");
+
+    const snackbar = getByTestId("feedback-snackbar");
+    expect(snackbar).toBeInTheDocument();
+    done();
+  }, 300);
 });

--- a/src/tests/services/sendFeedback.test.js
+++ b/src/tests/services/sendFeedback.test.js
@@ -1,0 +1,23 @@
+import nock from "nock";
+import { sendFeedback } from "../../components/services/sendFeedback";
+
+nock("http://localhost").post("/api/feedback").reply(200);
+nock("http://localhost").post("/api/feedback").reply(500);
+nock("http://localhost")
+  .post("/api/feedback")
+  .replyWithError("TEST: network request failed");
+
+test("positive server resoponse should resolve", async () => {
+  const res = await sendFeedback("whatever");
+  expect(res.success).toBe(true);
+});
+
+test("error when negative server response", async () => {
+  await expect(sendFeedback("whatever")).rejects.toThrow();
+});
+
+test("error when fetch throws error", async () => {
+  await expect(sendFeedback("whatever")).rejects.toThrow(
+    "TypeError: Network request failed"
+  );
+});

--- a/src/tests/services/sendFeedback.test.js
+++ b/src/tests/services/sendFeedback.test.js
@@ -13,23 +13,24 @@ afterEach(() => {
   return nock.restore();
 });
 
-test("error when fetch throws error", async () => {
-  nock("http://localhost").post("/api/feedback").replyWithError("error");
+test("check if promise rejects when fetch request fails", async () => {
+  nock("http://localhost")
+    .post("/api/feedback")
+    .replyWithError("thrown for testing purposes");
 
-  await expect(sendFeedback("whatever")).rejects.toThrow(
-    "TypeError: Network request failed"
-  );
+  await expect(sendFeedback("fake input")).rejects.toThrow();
 });
 
-test("error when negative server response", async () => {
-  nock("http://localhost").post("/api/feedback").reply(400);
+test("check if promise only resolves if server status code is 200", async () => {
+  nock("http://localhost")
+    .post("/api/feedback")
+    .reply(400)
+    .post("/api/feedback")
+    .reply(200)
+    .post("/api/feedback")
+    .reply(500);
 
-  await expect(sendFeedback("whatever")).rejects.toThrow();
-});
-
-test("positive server response should lead to resolved promise", async () => {
-  nock("http://localhost").post("/api/feedback").reply(200);
-
-  const res = await sendFeedback("whatever");
-  expect(res.success).toBe(true);
+  await expect(sendFeedback("fake input")).rejects.toThrow();
+  await expect(sendFeedback("fake input")).resolves.toBe(true);
+  await expect(sendFeedback("fake input")).rejects.toThrow();
 });


### PR DESCRIPTION
> Note: Branchname is deprecated: Just testing feedback functions and leaving authentication for another day was plenty of work and code for a pull request. Moved auth tests into their own issue: #89 .

added tests for `feedbackscreen`, introduced `sendFeedback` service to make testing easier
added tests for `CostumSnackbar`

- used `nock` to fake fetch requests in `sendFeedback.test.js`
- used `mockImplementation`, used to mock the `sendFeedback` service in order to make testing the ui behaviour easier.
- used mock functions to check if callbacks are called

closes #88 