### PR TITLE
fix/#59: removed second outer grid in app drawer to fix item placement

### DIFF
--- a/src/components/pageComponents/AppBarDrawer.js
+++ b/src/components/pageComponents/AppBarDrawer.js
@@ -120,8 +120,6 @@ export default function AppBarDrawer(props) {
             data-testid="drawer-divider"
             className={classes.divider}
           />
-        </Grid>
-        <Grid className={classes.list} item xs={9}>
           <List>
             {otherPages.map((item, index) => (
               <ListItem


### PR DESCRIPTION
closes #59 