### PR TITLE
refact/#135: detailscreen layout

### DIFF
--- a/src/components/pageComponents/Audiodetail.js
+++ b/src/components/pageComponents/Audiodetail.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { makeStyles, Typography } from "@material-ui/core/";
+import { makeStyles, Typography, Chip } from "@material-ui/core/";
 
 const useStyles = makeStyles((theme) => ({
   title: {
@@ -13,10 +13,13 @@ const useStyles = makeStyles((theme) => ({
     marginBottom: "8px",
   },
 
-  tag: {
-    color: theme.palette.text.main,
+  chip: {
     marginRight: "8px",
+    marginBottom: "16px",
+    marginTop: "8px",
     float: "left",
+    color: theme.palette.background.lightgrey,
+    background: theme.palette.primary.light,
   },
 }));
 
@@ -26,20 +29,16 @@ export default function AudioDetail(props) {
 
   return (
     <div>
-      <Typography variant="body1" className={classes.title}>
+      <Typography variant="h6" className={classes.title}>
         {data.title}
       </Typography>
-
       <audio controls className={classes.audio}>
         <source src={data.source} type="audio/mpeg" />
         Your browser does not support the audio element.
       </audio>
-
       {data.tags.map((tag, index) => {
         return (
-          <Typography variant="caption" className={classes.tag} key={index}>
-            {tag}
-          </Typography>
+          <Chip label={tag} size="small" key={index} className={classes.chip} />
         );
       })}
     </div>

--- a/src/components/pageComponents/TextDetail.js
+++ b/src/components/pageComponents/TextDetail.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { makeStyles, Typography } from "@material-ui/core/";
+import { makeStyles, Typography, Chip } from "@material-ui/core/";
 
 const useStyles = makeStyles((theme) => ({
   title: {
@@ -7,11 +7,13 @@ const useStyles = makeStyles((theme) => ({
     textAlign: "start",
   },
 
-  tag: {
-    color: theme.palette.text.main,
+  chip: {
     marginRight: "8px",
-    marginBottom: "8px",
+    marginBottom: "16px",
+    marginTop: "8px",
     float: "left",
+    color: theme.palette.background.lightgrey,
+    background: theme.palette.primary.light,
   },
 
   text: {
@@ -27,14 +29,12 @@ export default function TextDetail(props) {
   const { data } = props;
   return (
     <div className="ContentDetailText">
-      <Typography variant="body1" className={classes.title}>
+      <Typography variant="h6" className={classes.title}>
         {data.title}
       </Typography>
       {data.tags.map((tag, index) => {
         return (
-          <Typography variant="caption" className={classes.tag} key={index}>
-            {tag}
-          </Typography>
+          <Chip label={tag} size="small" key={index} className={classes.chip} />
         );
       })}
       <br></br>

--- a/src/components/pageComponents/TopAppBar.js
+++ b/src/components/pageComponents/TopAppBar.js
@@ -56,15 +56,8 @@ class TopAppBar extends React.Component {
   }
 
   render() {
-    const { classes } = this.props;
-    let header, visibilityOfFavoritesIcon;
-    if (this.props.title === "URfit") {
-      header = <AppBarLogo class={classes.logo} />;
-      visibilityOfFavoritesIcon = { visibility: "hidden" };
-    } else {
-      header = <AppBarTitle class={classes.title} title={this.props.title} />;
-      visibilityOfFavoritesIcon = { visibility: "visible" };
-    }
+    const { classes, title, favIcon } = this.props;
+
     return (
       <AppBar data-testid="appbar" className={classes.appBar}>
         <Toolbar>
@@ -83,7 +76,11 @@ class TopAppBar extends React.Component {
                 <BurgerMenu fontSize="large" />
               </IconButton>
             </Grid>
-            {header}
+            {this.props.title === "URfit" ? (
+              <AppBarLogo class={classes.logo} />
+            ) : (
+              <AppBarTitle class={classes.title} title={title} />
+            )}
             <Grid item>
               <IconButton
                 button="true"
@@ -91,7 +88,14 @@ class TopAppBar extends React.Component {
                 to={"/"}
                 data-testid="favorites-button"
               >
-                <Favorite className={classes.favorites} style={visibilityOfFavoritesIcon} />
+                <Favorite
+                  className={classes.favorites}
+                  style={
+                    favIcon === "visible"
+                      ? { visibility: "visible" }
+                      : { visibility: "hidden" }
+                  }
+                />
               </IconButton>
             </Grid>
           </Grid>

--- a/src/components/pageComponents/Videodetail.js
+++ b/src/components/pageComponents/Videodetail.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { makeStyles, Typography } from "@material-ui/core/";
+import { makeStyles, Typography, Chip } from "@material-ui/core/";
 
 const useStyles = makeStyles((theme) => ({
   video: {
@@ -13,10 +13,13 @@ const useStyles = makeStyles((theme) => ({
     marginBottom: "8px",
   },
 
-  tag: {
-    color: theme.palette.text.main,
+  chip: {
     marginRight: "8px",
+    marginBottom: "16px",
+    marginTop: "8px",
     float: "left",
+    color: theme.palette.background.lightgrey,
+    background: theme.palette.primary.light,
   },
 }));
 
@@ -26,6 +29,9 @@ export default function VideoDetail(props) {
 
   return (
     <div>
+      <Typography variant="h6" className={classes.title}>
+        {data.title}
+      </Typography>
       <iframe
         title="testvideo"
         className={classes.video}
@@ -34,14 +40,9 @@ export default function VideoDetail(props) {
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
         allowFullScreen
       ></iframe>
-      <Typography variant="body1" className={classes.title}>
-        {data.title}
-      </Typography>
       {data.tags.map((tag, index) => {
         return (
-          <Typography variant="caption" className={classes.tag} key={index}>
-            {tag}
-          </Typography>
+          <Chip label={tag} size="small" key={index} className={classes.chip} />
         );
       })}
     </div>

--- a/src/components/pages/CategoryList.js
+++ b/src/components/pages/CategoryList.js
@@ -58,7 +58,7 @@ export default function CategoryList(props) {
 
   return (
     <div>
-      <TopAppBar data-testid="appbar" title={title} />
+      <TopAppBar data-testid="appbar" title={title} favIcon="visible" />
       {loading ? (
         <CircularProgress />
       ) : (

--- a/src/components/pages/ConditionsOfUsescreen.js
+++ b/src/components/pages/ConditionsOfUsescreen.js
@@ -28,7 +28,11 @@ export default function ConditionsOfUseScreen(props) {
   const classes = useStyles();
   return (
     <div className="ConditionsOfUseScreen">
-      <TopAppBar data-testid="appbar" title="Nutzungsbedingungen" />
+      <TopAppBar
+        data-testid="appbar"
+        title="Nutzungsbedingungen"
+        favIcon="visible"
+      />
       <div className={classes.container}>
         <Typography variant="body1" className={classes.text} component="div">
           <ReactMarkdown source={conditions.text} />

--- a/src/components/pages/Contentlistscreen.js
+++ b/src/components/pages/Contentlistscreen.js
@@ -107,6 +107,7 @@ export default function Contentlistscreen(props) {
           match.params.subcategory.charAt(0).toUpperCase() +
           match.params.subcategory.slice(1)
         }
+        favIcon="visible"
       />
       <div className={classes.container}>
         <div className={classes.header}>

--- a/src/components/pages/Detailscreen.js
+++ b/src/components/pages/Detailscreen.js
@@ -6,6 +6,7 @@ import {
   Share as ShareIcon,
   FavoriteBorder as FavoriteOutlinedIcon,
 } from "@material-ui/icons";
+import TopAppBar from "../pageComponents/TopAppBar";
 import VideoDetail from "../pageComponents/Videodetail";
 import AudioDetail from "../pageComponents/Audiodetail";
 import TextDetail from "../pageComponents/TextDetail";
@@ -152,41 +153,44 @@ export default function Detailscreen(props) {
   };
 
   return (
-    <div className={classes.container}>
-      {loading ? (
-        <CircularProgress />
-      ) : (
-        <div>
-          <div className={classes.header}>
-            <Link to={backPath} replace>
-              <ArrowBackIcon className={classes.back} />
-            </Link>
+    <div>
+      <TopAppBar data-testid="appbar" title="URfit" favIcon="visible" />
+      <div className={classes.container}>
+        {loading ? (
+          <CircularProgress />
+        ) : (
+          <div>
+            <div className={classes.header}>
+              <Link to={backPath} replace>
+                <ArrowBackIcon className={classes.back} />
+              </Link>
 
-            <IconButton
-              size="small"
-              className={classes.share}
-              onClick={handleShareClick}
-            >
-              <ShareIcon />
-            </IconButton>
+              <IconButton
+                size="small"
+                className={classes.share}
+                onClick={handleShareClick}
+              >
+                <ShareIcon />
+              </IconButton>
 
-            <IconButton
-              size="small"
-              className={classes.favorite}
-              onClick={handleFavoriteClick}
-            >
-              {favorite ? <FavoriteIcon /> : <FavoriteOutlinedIcon />}
-            </IconButton>
-            <CustomSnackbar
-              open={snackbarOpen}
-              onClose={toggleSnackbar}
-              message={snackbarMessage}
-            ></CustomSnackbar>
+              <IconButton
+                size="small"
+                className={classes.favorite}
+                onClick={handleFavoriteClick}
+              >
+                {favorite ? <FavoriteIcon /> : <FavoriteOutlinedIcon />}
+              </IconButton>
+              <CustomSnackbar
+                open={snackbarOpen}
+                onClose={toggleSnackbar}
+                message={snackbarMessage}
+              ></CustomSnackbar>
+            </div>
+
+            {content}
           </div>
-
-          {content}
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/pages/Feedbackscreen.js
+++ b/src/components/pages/Feedbackscreen.js
@@ -83,7 +83,7 @@ class Feedbackscreen extends React.Component {
     const { classes } = this.props;
     return (
       <div className="Feedbackscreen">
-        <TopAppBar data-testid="appbar" title="Feedback" />
+        <TopAppBar data-testid="appbar" title="Feedback" favIcon="visible" />
         <div className={classes.container}>
           <Typography
             variant="body1"

--- a/src/components/pages/Imprintscreen.js
+++ b/src/components/pages/Imprintscreen.js
@@ -28,7 +28,7 @@ export default function Imprintscreen(props) {
   const classes = useStyles();
   return (
     <div className="Imprintscreen">
-      <TopAppBar data-testid="appbar" title="Impressum" />
+      <TopAppBar data-testid="appbar" title="Impressum" favIcon="visible" />
       <div className={classes.container}>
         <Typography variant="body1" className={classes.text} component="div">
           <ReactMarkdown source={imprint.text} />

--- a/src/components/pages/Mensascreen.js
+++ b/src/components/pages/Mensascreen.js
@@ -123,7 +123,11 @@ export class Mensascreen extends React.Component {
     } else {
       return (
         <div className="Mensascreen">
-          <TopAppBar data-testid="mensa-appBar" title="URfit" />
+          <TopAppBar
+            data-testid="mensa-appBar"
+            title="URfit"
+            favIcon="visible"
+          />
           <Grid container direction="column">
             <Grid
               container

--- a/src/components/pages/Settingsscreen.js
+++ b/src/components/pages/Settingsscreen.js
@@ -1,132 +1,136 @@
-import React from 'react'
-import { 
-    Button, 
-    Grid, 
-    makeStyles } from "@material-ui/core/";
-import TextField from '@material-ui/core/TextField';
-import Dialog from '@material-ui/core/Dialog';
-import DialogActions from '@material-ui/core/DialogActions';
-import DialogContent from '@material-ui/core/DialogContent';
-import DialogContentText from '@material-ui/core/DialogContentText';
-import DialogTitle from '@material-ui/core/DialogTitle';
+import React from "react";
+import { Button, Grid, makeStyles } from "@material-ui/core/";
+import TextField from "@material-ui/core/TextField";
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogContentText from "@material-ui/core/DialogContentText";
+import DialogTitle from "@material-ui/core/DialogTitle";
 
 import TopAppBar from "../pageComponents/TopAppBar";
 
 const useStyles = makeStyles((theme) => ({
-    container: {
-        margin: "24px", 
-    },
-    buttons: {
-        width: "100%"
-    },
-  }));
+  container: {
+    margin: "24px",
+  },
+  buttons: {
+    width: "100%",
+  },
+}));
 
-export default function Settingsscreen(){
-    const classes = useStyles();
-    const [openUsername, setUsernameOpen] = React.useState(false);
-    const [openDelete, setDeleteOpen] = React.useState(false);
+export default function Settingsscreen() {
+  const classes = useStyles();
+  const [openUsername, setUsernameOpen] = React.useState(false);
+  const [openDelete, setDeleteOpen] = React.useState(false);
 
-    const handleUsername = () => {
-        setUsernameOpen(true);
-    }
-    const handleCloseDialogUsername = () => {
-        setUsernameOpen(false);
-    }
+  const handleUsername = () => {
+    setUsernameOpen(true);
+  };
+  const handleCloseDialogUsername = () => {
+    setUsernameOpen(false);
+  };
 
-    const handleDelete = () => {
-        setDeleteOpen(true);
-    }
-    const handleCloseDialogDelete = () => {
-        setDeleteOpen(false);
-    }
+  const handleDelete = () => {
+    setDeleteOpen(true);
+  };
+  const handleCloseDialogDelete = () => {
+    setDeleteOpen(false);
+  };
 
-    return (
-        <div className="Settingsscreen">
-            <TopAppBar data-testid="appbar" title="Einstellungen" />
-            <div className={classes.container}>
-            <Grid container direction="column" spacing={3} >
-                <Grid item >
-                    <Button 
-                        className={ classes.buttons } 
-                        variant="contained" 
-                        color="default" 
-                        onClick={handleUsername}>
-                        Umbennen
-                    </Button>
-                    <Dialog 
-                        open={openUsername} 
-                        onClose={handleCloseDialogUsername} 
-                        aria-labelledby="form-dialog-title">
-                        <DialogTitle id="form-dialog-title">Nutzername ändern</DialogTitle>
-                        <DialogContent>
-                            <DialogContentText>
-                                Bitte geben sie einen neuen Nutzernamen ein.
-                            </DialogContentText>
-                            <TextField
-                                autoFocus
-                                margin="dense"
-                                id="name"
-                                label="Nutzername"
-                                type="text"
-                                value="Viktor"
-                                fullWidth
-                            />
-                        </DialogContent>
-                        <DialogActions>
-                            <Button 
-                                onClick={handleCloseDialogUsername} 
-                                color="primary">
-                                Abbrechen
-                            </Button>
-                            <Button 
-                                onClick={handleCloseDialogUsername} 
-                                color="primary" 
-                                autoFocus>
-                                Bestätigen
-                            </Button>
-                        </DialogActions>
-                    </Dialog>
-                    </Grid>
-                <Grid item>
-                    <Button 
-                        className={ classes.buttons } 
-                        variant="contained" 
-                        color="secondary" 
-                        onClick={handleDelete}>
-                        Konto löschen
-                    </Button>
-                        <Dialog
-                            open={openDelete}
-                            onClose={handleCloseDialogDelete}
-                            aria-labelledby="alert-dialog-title"
-                            aria-describedby="alert-dialog-description"
-                        >
-                            <DialogTitle id="alert-dialog-title">Möchten Sie ihr Konto wirklich löschen?</DialogTitle>
-                            <DialogContent>
-                            <DialogContentText id="alert-dialog-description">
-                                Wenn Sie ihr konto löschen, werden alle Ihre Daten unwiderruflich gelöscht. Dies kann nicht mehr rückgängig gemacht werden!
-                                <br></br>
-                                <br></br>
-                                Sind Sie sicher, dass Sie ihr Konto löschen wollen?
-                            </DialogContentText>
-                            </DialogContent>
-                            <DialogActions>
-                            <Button 
-                                onClick={handleCloseDialogDelete} 
-                                color="primary" 
-                                autoFocus>
-                                Zurück
-                            </Button>
-                            <Button 
-                                onClick={handleCloseDialogDelete} 
-                                color="secondary">
-                                Ja
-                            </Button>
-                            </DialogActions>
-                        </Dialog>
-                </Grid>
-            </Grid>
-            </div>
-        </div>
-    )
+  return (
+    <div className="Settingsscreen">
+      <TopAppBar data-testid="appbar" title="Einstellungen" favIcon="visible" />
+      <div className={classes.container}>
+        <Grid container direction="column" spacing={3}>
+          <Grid item>
+            <Button
+              className={classes.buttons}
+              variant="contained"
+              color="default"
+              onClick={handleUsername}
+            >
+              Umbennen
+            </Button>
+            <Dialog
+              open={openUsername}
+              onClose={handleCloseDialogUsername}
+              aria-labelledby="form-dialog-title"
+            >
+              <DialogTitle id="form-dialog-title">
+                Nutzername ändern
+              </DialogTitle>
+              <DialogContent>
+                <DialogContentText>
+                  Bitte geben sie einen neuen Nutzernamen ein.
+                </DialogContentText>
+                <TextField
+                  autoFocus
+                  margin="dense"
+                  id="name"
+                  label="Nutzername"
+                  type="text"
+                  value="Viktor"
+                  fullWidth
+                />
+              </DialogContent>
+              <DialogActions>
+                <Button onClick={handleCloseDialogUsername} color="primary">
+                  Abbrechen
+                </Button>
+                <Button
+                  onClick={handleCloseDialogUsername}
+                  color="primary"
+                  autoFocus
+                >
+                  Bestätigen
+                </Button>
+              </DialogActions>
+            </Dialog>
+          </Grid>
+          <Grid item>
+            <Button
+              className={classes.buttons}
+              variant="contained"
+              color="secondary"
+              onClick={handleDelete}
+            >
+              Konto löschen
+            </Button>
+            <Dialog
+              open={openDelete}
+              onClose={handleCloseDialogDelete}
+              aria-labelledby="alert-dialog-title"
+              aria-describedby="alert-dialog-description"
+            >
+              <DialogTitle id="alert-dialog-title">
+                Möchten Sie ihr Konto wirklich löschen?
+              </DialogTitle>
+              <DialogContent>
+                <DialogContentText id="alert-dialog-description">
+                  Wenn Sie ihr konto löschen, werden alle Ihre Daten
+                  unwiderruflich gelöscht. Dies kann nicht mehr rückgängig
+                  gemacht werden!
+                  <br></br>
+                  <br></br>
+                  Sind Sie sicher, dass Sie ihr Konto löschen wollen?
+                </DialogContentText>
+              </DialogContent>
+              <DialogActions>
+                <Button
+                  onClick={handleCloseDialogDelete}
+                  color="primary"
+                  autoFocus
+                >
+                  Zurück
+                </Button>
+                <Button onClick={handleCloseDialogDelete} color="secondary">
+                  Ja
+                </Button>
+              </DialogActions>
+            </Dialog>
+          </Grid>
+        </Grid>
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
Refactored TopAppBar to show Logo and HeartIcon depending on props.
Added ToppAppBar (with Logo and HeartIcon) for Detailscreen.
Refactored detail screens for text, video, audio: bigger title, display tags as chips.

Closes #135 